### PR TITLE
Feat: Allow specifying PROXY_AUTH values via env-var (allows IAP)

### DIFF
--- a/src/client/metabase-client.ts
+++ b/src/client/metabase-client.ts
@@ -33,6 +33,11 @@ export class MetabaseClient {
       timeout: 30000, // 30 second timeout to prevent hanging requests
     });
 
+    if (config.proxyAuthorization) {
+      this.logInfo("Using Proxy-Authorization header for proxy authentication.");
+      this.axiosInstance.defaults.headers.common["Proxy-Authorization"] = config.proxyAuthorization;
+    }
+
     if (config.apiKey) {
       this.logInfo("Using Metabase API Key for authentication.");
       this.axiosInstance.defaults.headers.common["X-API-Key"] = config.apiKey;

--- a/src/types/metabase.ts
+++ b/src/types/metabase.ts
@@ -7,6 +7,7 @@ export interface MetabaseConfig {
   username?: string;
   password?: string;
   apiKey?: string;
+  proxyAuthorization?: string;
 }
 
 export interface Dashboard {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -12,6 +12,7 @@ export function loadConfig(): MetabaseConfig {
   const username = process.env.METABASE_USERNAME;
   const password = process.env.METABASE_PASSWORD;
   const apiKey = process.env.METABASE_API_KEY;
+  const proxyAuthorization = process.env.METABASE_PROXY_AUTHORIZATION;
 
   if (!url) {
     throw new Error("METABASE_URL environment variable is required");
@@ -28,6 +29,7 @@ export function loadConfig(): MetabaseConfig {
     username,
     password,
     apiKey,
+    proxyAuthorization,
   };
 }
 


### PR DESCRIPTION
Hello,

We host MB behind Google IAP, so HTTP requests need to have a proxy auth bearer token. This allows us to handle login in our environment context.

Thank you!