### PR TITLE
feat: HTTP Stream transport with per-request credential injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,66 @@ node dist/server.js --write           # Write tools only
 node dist/server.js --read            # Read-only tools only
 ```
 
+## 🌐 HTTP Stream Transport (Shared Deployment)
+
+The server supports an **HTTP Stream transport** mode that lets a single deployed instance serve multiple users — each request provides its own Metabase credentials via headers. This is the recommended approach for cloud/SaaS deployments and is required by modern MCP clients like **Claude Code CLI**.
+
+### Why HTTP Stream?
+
+| | stdio (classic) | HTTP Stream (new) |
+|---|---|---|
+| Deployment | One process per user | One shared process |
+| Credentials | Env vars at startup | Per-request headers |
+| Claude Code CLI | ❌ Not supported | ✅ Supported |
+| Cursor, Windsurf | ✅ Supported | ✅ Supported |
+
+### Starting in HTTP Stream mode
+
+```bash
+MCP_TRANSPORT=http node dist/server.js
+# or with custom port:
+MCP_TRANSPORT=http PORT=8011 node dist/server.js --all
+```
+
+### Connecting from Claude Code CLI
+
+```bash
+claude mcp add --transport http metabase "https://your-deployment.example.com/mcp" \
+  --header "x-metabase-url: https://your-metabase-instance.com" \
+  --header "x-metabase-api-key: your_api_key"
+```
+
+Or add it globally (available in all projects):
+
+```bash
+claude mcp add --transport http --scope user metabase "https://your-deployment.example.com/mcp" \
+  --header "x-metabase-url: https://your-metabase-instance.com" \
+  --header "x-metabase-api-key: your_api_key"
+```
+
+### Request Headers
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| `x-metabase-url` | Yes* | Metabase instance URL. Can be omitted if `METABASE_URL` env var is set on the server. |
+| `x-metabase-api-key` | Yes** | Metabase API key |
+| `x-metabase-username` | Yes** | Metabase username (alternative to API key) |
+| `x-metabase-password` | Yes** | Metabase password (required if username is provided) |
+
+\* Falls back to `METABASE_URL` env var if not in header.
+\*\* Either `x-metabase-api-key` OR `x-metabase-username` + `x-metabase-password` is required.
+
+### Username/Password via headers
+
+```bash
+claude mcp add --transport http metabase "https://your-deployment.example.com/mcp" \
+  --header "x-metabase-url: https://your-metabase-instance.com" \
+  --header "x-metabase-username: admin@example.com" \
+  --header "x-metabase-password: secret"
+```
+
+---
+
 ## 🔌 Integration Examples
 
 ### Claude Desktop
@@ -379,6 +439,13 @@ npm install
 ### Build
 ```bash
 npm run build
+```
+
+### Tests
+```bash
+npm test
+# watch mode:
+npm run test:watch
 ```
 
 ### Development Mode

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "clean": "rm -rf build dist",
     "docker:build": "docker build -t metabase-mcp-server .",
     "docker:run": "docker run -it --rm metabase-mcp-server",
-    "docker:compose": "docker-compose up"
+    "docker:compose": "docker-compose up",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^0.6.1",
@@ -56,7 +58,8 @@
   },
   "devDependencies": {
     "@types/node": "^20.17.22",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^3.2.4"
   },
   "engines": {
     "node": ">=20.19.0",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,46 @@
+import { MetabaseClient } from "./client/metabase-client.js";
+
+/**
+ * Creates a per-request authenticate handler for HTTP Stream transport.
+ * Extracts Metabase credentials from request headers and returns a
+ * session-scoped MetabaseClient.
+ */
+export function createAuthenticateHandler() {
+  return (request: any): { metabaseClient: MetabaseClient } => {
+    const url = (request.headers['x-metabase-url'] as string) || process.env.METABASE_URL;
+    const apiKey = request.headers['x-metabase-api-key'] as string;
+    const username = request.headers['x-metabase-username'] as string;
+    const password = request.headers['x-metabase-password'] as string;
+
+    if (!url) {
+      throw new Response(null, {
+        status: 401,
+        statusText: 'Missing Metabase URL: provide x-metabase-url header or METABASE_URL env var',
+      });
+    }
+    if (!apiKey && (!username || !password)) {
+      throw new Response(null, {
+        status: 401,
+        statusText: 'Missing credentials: provide x-metabase-api-key or x-metabase-username + x-metabase-password headers',
+      });
+    }
+
+    const metabaseClient = new MetabaseClient({ url, apiKey, username, password });
+    return { metabaseClient };
+  };
+}
+
+/**
+ * Creates a client resolver that returns the appropriate MetabaseClient
+ * for the current request context.
+ * - HTTP mode: returns the per-session client from ctx.session.metabaseClient
+ * - stdio mode: returns the shared defaultClient
+ */
+export function createClientResolver(defaultClient: MetabaseClient | null) {
+  return (ctx?: any): MetabaseClient => {
+    const sessionClient = ctx?.session?.metabaseClient;
+    if (sessionClient) return sessionClient;
+    if (defaultClient) return defaultClient;
+    throw new Error('No MetabaseClient available — provide credentials via headers');
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import { addCardTools } from "./tools/card-tools.js";
 import { addTableTools } from "./tools/table-tools.js";
 import { addAdditionalTools } from "./tools/additional-tools.js";
 import { parseToolFilterOptions } from "./utils/tool-filters.js";
+import { createAuthenticateHandler, createClientResolver } from "./auth.js";
 
 // Parse command line arguments for tool filtering
 const filterOptions = parseToolFilterOptions();
@@ -24,15 +25,7 @@ if (!isHttpMode) {
   defaultClient = new MetabaseClient(config);
 }
 
-// getClient resolves the right MetabaseClient for the current request:
-// - stdio: always returns the shared defaultClient
-// - httpStream: returns the per-session client created in authenticate()
-const getClient = (ctx?: any): MetabaseClient => {
-  const sessionClient = ctx?.session?.metabaseClient;
-  if (sessionClient) return sessionClient;
-  if (defaultClient) return defaultClient;
-  throw new Error('No MetabaseClient available — provide credentials via headers');
-};
+const getClient = createClientResolver(defaultClient);
 
 // Build FastMCP server options
 const serverOptions: any = {
@@ -41,28 +34,7 @@ const serverOptions: any = {
 };
 
 if (isHttpMode) {
-  serverOptions.authenticate = (request: any) => {
-    const url = (request.headers['x-metabase-url'] as string) || process.env.METABASE_URL;
-    const apiKey = request.headers['x-metabase-api-key'] as string;
-    const username = request.headers['x-metabase-username'] as string;
-    const password = request.headers['x-metabase-password'] as string;
-
-    if (!url) {
-      throw new Response(null, {
-        status: 401,
-        statusText: 'Missing Metabase URL: provide x-metabase-url header or METABASE_URL env var',
-      });
-    }
-    if (!apiKey && (!username || !password)) {
-      throw new Response(null, {
-        status: 401,
-        statusText: 'Missing credentials: provide x-metabase-api-key or x-metabase-username + x-metabase-password headers',
-      });
-    }
-
-    const metabaseClient = new MetabaseClient({ url, apiKey, username, password });
-    return { metabaseClient };
-  };
+  serverOptions.authenticate = createAuthenticateHandler();
 }
 
 // Create FastMCP server

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,50 +13,87 @@ import { parseToolFilterOptions } from "./utils/tool-filters.js";
 // Parse command line arguments for tool filtering
 const filterOptions = parseToolFilterOptions();
 
-// Load and validate configuration
-const config = loadConfig();
-validateConfig(config);
+const isHttpMode = process.env.MCP_TRANSPORT === 'http';
 
-// Initialize Metabase client
-const metabaseClient = new MetabaseClient(config);
+// In stdio mode, create a single shared client from env vars at startup.
+// In httpStream mode, each client provides credentials via request headers.
+let defaultClient: MetabaseClient | null = null;
+if (!isHttpMode) {
+  const config = loadConfig();
+  validateConfig(config);
+  defaultClient = new MetabaseClient(config);
+}
 
-// Create FastMCP server
-const server = new FastMCP({
+// getClient resolves the right MetabaseClient for the current request:
+// - stdio: always returns the shared defaultClient
+// - httpStream: returns the per-session client created in authenticate()
+const getClient = (ctx?: any): MetabaseClient => {
+  const sessionClient = ctx?.session?.metabaseClient;
+  if (sessionClient) return sessionClient;
+  if (defaultClient) return defaultClient;
+  throw new Error('No MetabaseClient available — provide credentials via headers');
+};
+
+// Build FastMCP server options
+const serverOptions: any = {
   name: "metabase-server",
   version: "2.0.1",
-});
+};
 
-// Override addTool to apply filtering
+if (isHttpMode) {
+  serverOptions.authenticate = (request: any) => {
+    const url = (request.headers['x-metabase-url'] as string) || process.env.METABASE_URL;
+    const apiKey = request.headers['x-metabase-api-key'] as string;
+    const username = request.headers['x-metabase-username'] as string;
+    const password = request.headers['x-metabase-password'] as string;
+
+    if (!url) {
+      throw new Response(null, {
+        status: 401,
+        statusText: 'Missing Metabase URL: provide x-metabase-url header or METABASE_URL env var',
+      });
+    }
+    if (!apiKey && (!username || !password)) {
+      throw new Response(null, {
+        status: 401,
+        statusText: 'Missing credentials: provide x-metabase-api-key or x-metabase-username + x-metabase-password headers',
+      });
+    }
+
+    const metabaseClient = new MetabaseClient({ url, apiKey, username, password });
+    return { metabaseClient };
+  };
+}
+
+// Create FastMCP server
+const server = new FastMCP(serverOptions);
+
+// Override addTool to apply tool filtering (unchanged behavior)
 const originalAddTool = server.addTool.bind(server);
 server.addTool = function(toolConfig: any) {
   const { metadata = {}, ...restConfig } = toolConfig;
   const { isWrite, isEssential, isRead } = metadata;
 
-  // Apply filtering based on selected mode
   switch (filterOptions.mode) {
     case 'essential':
-      // Only load essential tools
       if (!isEssential) return;
       break;
     case 'write':
-      // Load read and write tools
       if (!isRead && !isWrite) return;
       break;
     case 'all':
-      // Load all tools - no filtering
       break;
   }
 
-  // Register the tool
   originalAddTool(restConfig);
 };
 
-// Adding all tools to the server
-addDashboardTools(server, metabaseClient);
-addDatabaseTools(server, metabaseClient);
-addCardTools(server, metabaseClient);
-addTableTools(server, metabaseClient);
-addAdditionalTools(server, metabaseClient);
+// Adding all tools — each execute calls getClient(context) internally
+addDashboardTools(server, getClient);
+addDatabaseTools(server, getClient);
+addCardTools(server, getClient);
+addTableTools(server, getClient);
+addAdditionalTools(server, getClient);
 
 // Log filtering status
 console.error(`INFO: Tool filtering mode: ${filterOptions.mode} ${filterOptions.mode === 'essential' ? '(default)' : ''}`);
@@ -74,6 +111,17 @@ switch (filterOptions.mode) {
 }
 
 // Start the server
-server.start({
-  transportType: "stdio",
-});
+if (isHttpMode) {
+  console.error(`INFO: Starting HTTP Stream transport on port ${process.env.PORT || '8011'}`);
+  server.start({
+    transportType: "httpStream",
+    httpStream: {
+      port: parseInt(process.env.PORT || '8011'),
+      endpoint: "/mcp",
+    },
+  });
+} else {
+  server.start({
+    transportType: "stdio",
+  });
+}

--- a/src/tools/additional-tools.ts
+++ b/src/tools/additional-tools.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { MetabaseClient } from "../client/metabase-client.js";
 
-export function addAdditionalTools(server: any, metabaseClient: MetabaseClient) {
+export function addAdditionalTools(server: any, getClient: (ctx?: any) => MetabaseClient) {
 
   /**
    * Get all items within a collection
@@ -20,7 +20,8 @@ export function addAdditionalTools(server: any, metabaseClient: MetabaseClient) 
     parameters: z.object({
       collection_id: z.number().describe("Collection ID"),
     }).strict(),
-    execute: async (args: { collection_id: number }) => {
+    execute: async (args: { collection_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.apiCall(
           "GET",
@@ -64,7 +65,8 @@ export function addAdditionalTools(server: any, metabaseClient: MetabaseClient) 
       item_type: "card" | "dashboard";
       item_id: number;
       collection_id: number | null;
-    }) => {
+    }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.apiCall(
           "PUT",
@@ -106,7 +108,8 @@ export function addAdditionalTools(server: any, metabaseClient: MetabaseClient) 
       table_db_id: z.number().optional().describe("Filter by database ID"),
       limit: z.number().optional().describe("Maximum number of results"),
     }).strict(),
-    execute: async (args: any) => {
+    execute: async (args: any, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const { q, ...other } = args;
         const params = new URLSearchParams({ q });
@@ -144,7 +147,8 @@ export function addAdditionalTools(server: any, metabaseClient: MetabaseClient) 
     parameters: z.object({
       archived: z.boolean().optional().default(false).describe("Include archived collections"),
     }).strict(),
-    execute: async (args: { archived?: boolean } = {}) => {
+    execute: async (args: { archived?: boolean } = {}, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const collections = await metabaseClient.getCollections(args.archived || false);
         return JSON.stringify(collections, null, 2);
@@ -177,7 +181,8 @@ export function addAdditionalTools(server: any, metabaseClient: MetabaseClient) 
       parent_id: z.number().optional().describe("Parent collection ID for nested organization"),
       color: z.string().optional().describe("Color for the collection (hex code)"),
     }).strict(),
-    execute: async (args: { name: string; description?: string; parent_id?: number; color?: string }) => {
+    execute: async (args: { name: string; description?: string; parent_id?: number; color?: string }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const collection = await metabaseClient.createCollection(args);
         return JSON.stringify(collection, null, 2);
@@ -212,7 +217,8 @@ export function addAdditionalTools(server: any, metabaseClient: MetabaseClient) 
       parent_id: z.number().optional().describe("New parent collection ID"),
       color: z.string().optional().describe("New color for the collection"),
     }).strict(),
-    execute: async (args: { collection_id: number; name?: string; description?: string; parent_id?: number; color?: string }) => {
+    execute: async (args: { collection_id: number; name?: string; description?: string; parent_id?: number; color?: string }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const { collection_id, ...updates } = args;
         const collection = await metabaseClient.updateCollection(collection_id, updates);
@@ -240,7 +246,8 @@ export function addAdditionalTools(server: any, metabaseClient: MetabaseClient) 
     parameters: z.object({
       collection_id: z.number().describe("The ID of the collection to delete"),
     }).strict(),
-    execute: async (args: { collection_id: number }) => {
+    execute: async (args: { collection_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         await metabaseClient.deleteCollection(args.collection_id);
         return JSON.stringify({
@@ -271,7 +278,8 @@ export function addAdditionalTools(server: any, metabaseClient: MetabaseClient) 
     parameters: z.object({
       include_deactivated: z.boolean().optional().default(false).describe("Include deactivated users"),
     }).strict(),
-    execute: async (args: { include_deactivated?: boolean } = {}) => {
+    execute: async (args: { include_deactivated?: boolean } = {}, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const users = await metabaseClient.getUsers(args.include_deactivated || false);
         return JSON.stringify(users, null, 2);
@@ -299,7 +307,8 @@ export function addAdditionalTools(server: any, metabaseClient: MetabaseClient) 
       query: z.string().describe("The SQL query to execute in the playground"),
       display: z.string().optional().default("table").describe("Display type (table, bar, line, etc.)"),
     }).strict(),
-    execute: async (args: { query: string; display?: string }) => {
+    execute: async (args: { query: string; display?: string }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const payload = {
           dataset_query: {

--- a/src/tools/card-tools.ts
+++ b/src/tools/card-tools.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { MetabaseClient } from "../client/metabase-client.js";
 
-export function addCardTools(server: any, metabaseClient: MetabaseClient) {
+export function addCardTools(server: any, getClient: (ctx?: any) => MetabaseClient) {
 
   /**
    * List all available Metabase cards
@@ -22,7 +22,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
       f: z.string().optional().describe("Filter by source (e.g., 'models')"),
       model_id: z.number().optional().describe("Filter by model_id"),
     }).strict(),
-    execute: async (args: { f?: string; model_id?: number } = {}) => {
+    execute: async (args: { f?: string; model_id?: number } = {}, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const cards = await metabaseClient.getCards(args);
         return JSON.stringify(cards, null, 2);
@@ -51,7 +52,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       card_id: z.number().describe("Card ID"),
     }).strict(),
-    execute: async (args: { card_id: number }) => {
+    execute: async (args: { card_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const card = await metabaseClient.getCard(args.card_id);
         return JSON.stringify(card, null, 2);
@@ -95,7 +97,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
       collection_id: z.number().optional().describe("Collection to save in"),
       database_id: z.number().optional().describe("Database ID"),
     }).strict(),
-    execute: async (args: any) => {
+    execute: async (args: any, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const card = await metabaseClient.createCard(args);
         return JSON.stringify(card, null, 2);
@@ -136,7 +139,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
       card_id: number;
       updates: any;
       query_params?: any;
-    }) => {
+    }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const card = await metabaseClient.updateCard(
           args.card_id,
@@ -174,7 +178,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
         .default(false)
         .describe("Hard delete if true, else archive"),
     }).strict(),
-    execute: async (args: { card_id: number; hard_delete?: boolean }) => {
+    execute: async (args: { card_id: number; hard_delete?: boolean }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         await metabaseClient.deleteCard(args.card_id, args.hard_delete || false);
         return JSON.stringify(
@@ -229,7 +234,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
       ignore_cache?: boolean;
       collection_preview?: boolean;
       dashboard_id?: number;
-    }) => {
+    }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.executeCard(args.card_id, {
           ignore_cache: args.ignore_cache,
@@ -270,7 +276,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
       card_id: number;
       export_format: string;
       parameters?: any;
-    }) => {
+    }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.executeCardQueryWithFormat(
           args.card_id,
@@ -305,7 +312,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       card_id: z.number().describe("Card ID"),
     }).strict(),
-    execute: async (args: { card_id: number }) => {
+    execute: async (args: { card_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.copyCard(args.card_id);
         return JSON.stringify(result, null, 2);
@@ -336,7 +344,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       card_id: z.number().describe("Card ID"),
     }).strict(),
-    execute: async (args: { card_id: number }) => {
+    execute: async (args: { card_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.getCardDashboards(args.card_id);
         return JSON.stringify(result, null, 2);
@@ -363,7 +372,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
     name: "list_embeddable_cards",
     description: "Retrieve all Metabase cards configured for embedding in external applications (requires admin privileges) - use this to audit embedded content, manage external integrations, or review public-facing analytics",
     metadata: { isRead: true },
-    execute: async () => {
+    execute: async (_args: any, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.getEmbeddableCards();
         return JSON.stringify(result, null, 2);
@@ -393,7 +403,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       card_id: z.number().describe("Card ID"),
     }).strict(),
-    execute: async (args: { card_id: number }) => {
+    execute: async (args: { card_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.createCardPublicLink(args.card_id);
         return JSON.stringify(result, null, 2);
@@ -423,7 +434,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       card_id: z.number().describe("Card ID"),
     }).strict(),
-    execute: async (args: { card_id: number }) => {
+    execute: async (args: { card_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.deleteCardPublicLink(args.card_id);
         return JSON.stringify(result, null, 2);
@@ -450,7 +462,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
     name: "list_public_cards",
     description: "Retrieve all Metabase cards that have public URLs enabled (requires admin privileges) - use this to audit publicly accessible content, review security settings, or manage external data sharing",
     metadata: { isRead: true },
-    execute: async () => {
+    execute: async (_args: any, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.getPublicCards();
         return JSON.stringify(result, null, 2);
@@ -489,7 +502,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
       card_ids: number[];
       collection_id?: number;
       dashboard_id?: number;
-    }) => {
+    }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.moveCards(
           args.card_ids,
@@ -526,7 +540,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
       card_ids: z.array(z.number()).describe("Card IDs to move"),
       collection_id: z.number().optional().describe("Target collection ID"),
     }).strict(),
-    execute: async (args: { card_ids: number[]; collection_id?: number }) => {
+    execute: async (args: { card_ids: number[]; collection_id?: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.moveCardsToCollection(
           args.card_ids,
@@ -561,7 +576,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
       card_id: z.number().describe("Card ID"),
       parameters: z.object({}).passthrough().optional().describe("Execution parameters"),
     }).strict(),
-    execute: async (args: { card_id: number; parameters?: any }) => {
+    execute: async (args: { card_id: number; parameters?: any }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.executePivotCardQuery(
           args.card_id,
@@ -597,7 +613,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
       card_id: z.number().describe("Card ID"),
       param_key: z.string().describe("Parameter key"),
     }).strict(),
-    execute: async (args: { card_id: number; param_key: string }) => {
+    execute: async (args: { card_id: number; param_key: string }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.getCardParamValues(
           args.card_id,
@@ -639,7 +656,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
       card_id: number;
       param_key: string;
       query: string;
-    }) => {
+    }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.searchCardParamValues(
           args.card_id,
@@ -681,7 +699,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
       card_id: number;
       param_key: string;
       value: string;
-    }) => {
+    }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.getCardParamRemapping(
           args.card_id,
@@ -715,7 +734,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       card_id: z.number().describe("Card ID"),
     }).strict(),
-    execute: async (args: { card_id: number }) => {
+    execute: async (args: { card_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.getCardQueryMetadata(args.card_id);
         return JSON.stringify(result, null, 2);
@@ -762,7 +782,8 @@ export function addCardTools(server: any, metabaseClient: MetabaseClient) {
       last_cursor?: string | number;
       query?: string;
       exclude_ids?: number[];
-    }) => {
+    }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.getCardSeries(args.card_id, {
           last_cursor: args.last_cursor,

--- a/src/tools/dashboard-tools.ts
+++ b/src/tools/dashboard-tools.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { MetabaseClient } from "../client/metabase-client.js";
 
-export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
+export function addDashboardTools(server: any, getClient: (ctx?: any) => MetabaseClient) {
   /**
    * List all available dashboards
    *
@@ -16,7 +16,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
     description:
       "Retrieve all Metabase dashboards - use this to discover available dashboards, get an overview of analytical content, or find specific dashboards",
     metadata: { isEssential: true, isRead: true },
-    execute: async () => {
+    execute: async (_args: any, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const dashboards = await metabaseClient.getDashboards();
         return JSON.stringify(dashboards, null, 2);
@@ -48,7 +49,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       dashboard_id: z.number().describe("The ID of the dashboard to retrieve"),
     }).strict(),
-    execute: async (args: { dashboard_id: number }) => {
+    execute: async (args: { dashboard_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const dashboard = await metabaseClient.getDashboard(args.dashboard_id);
         return JSON.stringify(dashboard, null, 2);
@@ -80,7 +82,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       dashboard_id: z.number().describe("The ID of the dashboard"),
     }).strict(),
-    execute: async (args: { dashboard_id: number }) => {
+    execute: async (args: { dashboard_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const dashboard = await metabaseClient.getDashboard(args.dashboard_id);
         const cards = dashboard.dashcards || [];
@@ -113,7 +116,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       dashboard_id: z.number().describe("The ID of the dashboard"),
     }).strict(),
-    execute: async (args: { dashboard_id: number }) => {
+    execute: async (args: { dashboard_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.getDashboardRelatedEntities(
           args.dashboard_id
@@ -147,7 +151,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       dashboard_id: z.number().describe("The ID of the dashboard"),
     }).strict(),
-    execute: async (args: { dashboard_id: number }) => {
+    execute: async (args: { dashboard_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.getDashboardRevisions(
           args.dashboard_id
@@ -177,7 +182,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
     metadata: { isRead: true },
     description:
       "Retrieve all Metabase dashboards configured for embedding (requires superuser) - use this to audit embedded content or manage external integrations",
-    execute: async () => {
+    execute: async (_args: any, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const dashboards = await metabaseClient.getEmbeddableDashboards();
         return JSON.stringify(dashboards, null, 2);
@@ -205,7 +211,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
     metadata: { isRead: true },
     description:
       "Retrieve all Metabase dashboards with public URLs enabled (requires superuser) - use this to audit publicly accessible content or review security settings",
-    execute: async () => {
+    execute: async (_args: any, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const dashboards = await metabaseClient.getPublicDashboards();
         return JSON.stringify(dashboards, null, 2);
@@ -261,7 +268,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
       parameters?: any[];
       collection_id?: number;
       collection_position?: number;
-    }) => {
+    }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const dashboard = await metabaseClient.createDashboard(args);
         return JSON.stringify(dashboard, null, 2);
@@ -293,7 +301,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       dashboard_id: z.number().describe("The ID of the dashboard"),
     }).strict(),
-    execute: async (args: { dashboard_id: number }) => {
+    execute: async (args: { dashboard_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.createDashboardPublicLink(
           args.dashboard_id
@@ -351,7 +360,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
       description?: string;
       collection_id?: number;
       collection_position?: number;
-    }) => {
+    }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const { from_dashboard_id, ...copyData } = args;
         const dashboard = await metabaseClient.copyDashboard(
@@ -436,7 +446,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
       visualization_settings?: any;
       parameter_mappings?: any[];
       series?: any[];
-    }) => {
+    }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const { dashboard_id, ...cardData } = args;
         const result = await metabaseClient.addCardToDashboard(
@@ -501,7 +512,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
       col?: number;
       size_x?: number;
       size_y?: number;
-    }) => {
+    }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const displayType = args.display_type || "text";
         const sizeY = args.size_y || (displayType === "heading" ? 1 : 2);
@@ -556,7 +568,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       dashboard_id: z.number().describe("The ID of the dashboard"),
     }).strict(),
-    execute: async (args: { dashboard_id: number }) => {
+    execute: async (args: { dashboard_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.favoriteDashboard(
           args.dashboard_id
@@ -592,7 +605,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
       dashboard_id: z.number().describe("The ID of the dashboard"),
       revision_id: z.number().describe("The revision ID to revert to"),
     }).strict(),
-    execute: async (args: { dashboard_id: number; revision_id: number }) => {
+    execute: async (args: { dashboard_id: number; revision_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.revertDashboard(
           args.dashboard_id,
@@ -630,7 +644,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
         .passthrough()
         .describe("Dashboard object to save"),
     }).strict(),
-    execute: async (args: { dashboard: any }) => {
+    execute: async (args: { dashboard: any }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.saveDashboard(args.dashboard);
         return JSON.stringify(result, null, 2);
@@ -667,7 +682,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
         .passthrough()
         .describe("Dashboard object to save"),
     }).strict(),
-    execute: async (args: { parent_collection_id: number; dashboard: any }) => {
+    execute: async (args: { parent_collection_id: number; dashboard: any }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.saveDashboardToCollection(
           args.parent_collection_id,
@@ -745,7 +761,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
         .describe("Embedding parameters"),
       position: z.number().optional().describe("Dashboard position"),
     }).strict(),
-    execute: async (args: { dashboard_id: number; [key: string]: any }) => {
+    execute: async (args: { dashboard_id: number; [key: string]: any }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const { dashboard_id, ...updates } = args;
         const dashboard = await metabaseClient.updateDashboard(
@@ -805,7 +822,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
         )
         .describe("Array of card configurations"),
     }).strict(),
-    execute: async (args: { dashboard_id: number; cards: any[] }) => {
+    execute: async (args: { dashboard_id: number; cards: any[] }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.updateDashboardCards(
           args.dashboard_id,
@@ -846,7 +864,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
         .default(false)
         .describe("Whether to permanently delete (true) or archive (false)"),
     }).strict(),
-    execute: async (args: { dashboard_id: number; hard_delete?: boolean }) => {
+    execute: async (args: { dashboard_id: number; hard_delete?: boolean }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         await metabaseClient.deleteDashboard(
           args.dashboard_id,
@@ -889,7 +908,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       dashboard_id: z.number().describe("The ID of the dashboard"),
     }).strict(),
-    execute: async (args: { dashboard_id: number }) => {
+    execute: async (args: { dashboard_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         await metabaseClient.deleteDashboardPublicLink(args.dashboard_id);
         return JSON.stringify(
@@ -931,7 +951,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
       dashboard_id: z.number().describe("The ID of the dashboard"),
       dashcard_ids: z.array(z.number()).describe("Array of dashcard IDs to remove (the 'id' field from dashcards, not 'card_id')"),
     }).strict(),
-    execute: async (args: { dashboard_id: number; dashcard_ids: number[] }) => {
+    execute: async (args: { dashboard_id: number; dashcard_ids: number[] }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.removeCardsFromDashboard(
           args.dashboard_id,
@@ -965,7 +986,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       dashboard_id: z.number().describe("The ID of the dashboard"),
     }).strict(),
-    execute: async (args: { dashboard_id: number }) => {
+    execute: async (args: { dashboard_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.unfavoriteDashboard(
           args.dashboard_id
@@ -1003,7 +1025,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
         .describe("The ID of the dashboard containing the card"),
       card_id: z.number().describe("The ID of the card to execute"),
     }).strict(),
-    execute: async (args: { dashboard_id: number; card_id: number }) => {
+    execute: async (args: { dashboard_id: number; card_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.executeCard(args.card_id);
         return JSON.stringify(
@@ -1049,7 +1072,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
         .optional()
         .describe("Maximum number of results to return"),
     }).strict(),
-    execute: async (args: { query: string; limit?: number }) => {
+    execute: async (args: { query: string; limit?: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const dashboards = await metabaseClient.getDashboards();
         const filtered = dashboards.filter(
@@ -1103,7 +1127,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
         size_y: z.number().optional().describe("Height of the card"),
       }).passthrough().describe("Properties to update on the dashcard"),
     }).strict(),
-    execute: async (args: { dashboard_id: number; dashcard_id: number; updates: any }) => {
+    execute: async (args: { dashboard_id: number; dashcard_id: number; updates: any }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.updateDashcard(
           args.dashboard_id,
@@ -1140,7 +1165,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       dashboard_id: z.number().describe("The ID of the dashboard"),
     }).strict(),
-    execute: async (args: { dashboard_id: number }) => {
+    execute: async (args: { dashboard_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const dashboard = await metabaseClient.getDashboard(args.dashboard_id);
         const dashcards = (dashboard as any).dashcards || [];
@@ -1356,7 +1382,8 @@ export function addDashboardTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       dashboard_id: z.number().describe("The ID of the dashboard to audit"),
     }).strict(),
-    execute: async (args: { dashboard_id: number }) => {
+    execute: async (args: { dashboard_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const dashboard = await metabaseClient.getDashboard(args.dashboard_id);
         const dashcards = (dashboard as any).dashcards || [];

--- a/src/tools/database-tools.ts
+++ b/src/tools/database-tools.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { MetabaseClient } from "../client/metabase-client.js";
 
-export function addDatabaseTools(server: any, metabaseClient: MetabaseClient) {
+export function addDatabaseTools(server: any, getClient: (ctx?: any) => MetabaseClient) {
 
   /**
    * List all available databases
@@ -16,7 +16,8 @@ export function addDatabaseTools(server: any, metabaseClient: MetabaseClient) {
     name: "list_databases",
     description: "Retrieve all database connections in Metabase - use this to discover available data sources, check connection status, or get an overview of connected databases",
     metadata: { isEssential: true, isRead: true },
-    execute: async () => {
+    execute: async (_args: any, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const databases = await metabaseClient.getDatabases();
         return JSON.stringify(databases, null, 2);
@@ -43,7 +44,8 @@ export function addDatabaseTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       database_id: z.number().describe("The ID of the database to retrieve"),
     }).strict(),
-    execute: async (args: { database_id: number }) => {
+    execute: async (args: { database_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const database = await metabaseClient.getDatabase(args.database_id);
         return JSON.stringify(database, null, 2);
@@ -84,7 +86,8 @@ export function addDatabaseTools(server: any, metabaseClient: MetabaseClient) {
       is_on_demand: z.boolean().optional().describe("Whether database is on-demand"),
       schedules: z.object({}).passthrough().optional().describe("Sync schedules"),
     }).strict(),
-    execute: async (args: { engine: string; name: string; details: any; is_full_sync?: boolean; is_on_demand?: boolean; schedules?: any }) => {
+    execute: async (args: { engine: string; name: string; details: any; is_full_sync?: boolean; is_on_demand?: boolean; schedules?: any }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const database = await metabaseClient.createDatabase(args);
         return JSON.stringify(database, null, 2);
@@ -123,7 +126,8 @@ export function addDatabaseTools(server: any, metabaseClient: MetabaseClient) {
       is_on_demand: z.boolean().optional().describe("Whether database is on-demand"),
       schedules: z.object({}).passthrough().optional().describe("Updated sync schedules"),
     }).strict(),
-    execute: async (args: { database_id: number; [key: string]: any }) => {
+    execute: async (args: { database_id: number; [key: string]: any }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const { database_id, ...updates } = args;
         const database = await metabaseClient.updateDatabase(database_id, updates);
@@ -151,7 +155,8 @@ export function addDatabaseTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       database_id: z.number().describe("The ID of the database to delete"),
     }).strict(),
-    execute: async (args: { database_id: number }) => {
+    execute: async (args: { database_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         await metabaseClient.deleteDatabase(args.database_id);
         return JSON.stringify({
@@ -195,7 +200,8 @@ export function addDatabaseTools(server: any, metabaseClient: MetabaseClient) {
         password: z.string().describe("Database password"),
       }).passthrough().describe("Database connection details to validate"),
     }).strict(),
-    execute: async (args: { engine: string; details: any }) => {
+    execute: async (args: { engine: string; details: any }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.validateDatabase(args.engine, args.details);
         return JSON.stringify(result, null, 2);
@@ -217,7 +223,8 @@ export function addDatabaseTools(server: any, metabaseClient: MetabaseClient) {
   server.addTool({
     name: "add_sample_database",
     description: "Add the built-in Metabase sample database with demo data - use this for testing, learning, or exploring Metabase features",
-    execute: async () => {
+    execute: async (_args: any, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const database = await metabaseClient.addSampleDatabase();
         return JSON.stringify(database, null, 2);
@@ -243,7 +250,8 @@ export function addDatabaseTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       database_id: z.number().describe("The ID of the database to check"),
     }).strict(),
-    execute: async (args: { database_id: number }) => {
+    execute: async (args: { database_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.checkDatabaseHealth(args.database_id);
         return JSON.stringify(result, null, 2);
@@ -269,7 +277,8 @@ export function addDatabaseTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       database_id: z.number().describe("The ID of the database"),
     }).strict(),
-    execute: async (args: { database_id: number }) => {
+    execute: async (args: { database_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const metadata = await metabaseClient.getDatabaseMetadata(args.database_id);
         return JSON.stringify(metadata, null, 2);
@@ -295,7 +304,8 @@ export function addDatabaseTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       database_id: z.number().describe("The ID of the database"),
     }).strict(),
-    execute: async (args: { database_id: number }) => {
+    execute: async (args: { database_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const schemas = await metabaseClient.getDatabaseSchemas(args.database_id);
         return JSON.stringify(schemas, null, 2);
@@ -323,7 +333,8 @@ export function addDatabaseTools(server: any, metabaseClient: MetabaseClient) {
       database_id: z.number().describe("The ID of the database"),
       schema_name: z.string().describe("The name of the schema"),
     }).strict(),
-    execute: async (args: { database_id: number; schema_name: string }) => {
+    execute: async (args: { database_id: number; schema_name: string }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const schema = await metabaseClient.getDatabaseSchema(args.database_id, args.schema_name);
         return JSON.stringify(schema, null, 2);
@@ -358,7 +369,8 @@ export function addDatabaseTools(server: any, metabaseClient: MetabaseClient) {
         value: z.unknown().describe("Parameter value"),
       }).passthrough()).optional().describe("Optional query parameters for parameterized queries"),
     }).strict(),
-    execute: async (args: { database_id: number; query: string; parameters?: any[] }) => {
+    execute: async (args: { database_id: number; query: string; parameters?: any[] }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.executeQuery(args.database_id, args.query, args.parameters || []);
         return JSON.stringify(result, null, 2);
@@ -385,7 +397,8 @@ export function addDatabaseTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       database_id: z.number().describe("The ID of the database to sync"),
     }).strict(),
-    execute: async (args: { database_id: number }) => {
+    execute: async (args: { database_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.syncDatabaseSchema(args.database_id);
         return JSON.stringify({

--- a/src/tools/table-tools.ts
+++ b/src/tools/table-tools.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { MetabaseClient } from "../client/metabase-client.js";
 
-export function addTableTools(server: any, metabaseClient: MetabaseClient) {
+export function addTableTools(server: any, getClient: (ctx?: any) => MetabaseClient) {
 
   // Metabase API reference (OpenAPI):
   // - Hosted: https://www.metabase.com/docs/latest/api.json
@@ -27,7 +27,8 @@ export function addTableTools(server: any, metabaseClient: MetabaseClient) {
         .optional()
         .describe("Optional list of table IDs to filter by"),
     }).strict(),
-    execute: async (args: { ids?: number[] } = {}) => {
+    execute: async (args: { ids?: number[] } = {}, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.getTables(args.ids);
         return JSON.stringify(result, null, 2);
@@ -85,7 +86,8 @@ export function addTableTools(server: any, metabaseClient: MetabaseClient) {
       owner_user_id?: number;
       show_in_getting_started?: boolean;
       entity_type?: string;
-    }) => {
+    }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const { ids, ...updates } = args;
         const result = await metabaseClient.updateTables(ids, updates);
@@ -137,7 +139,8 @@ export function addTableTools(server: any, metabaseClient: MetabaseClient) {
       include_sensitive_fields?: boolean;
       include_hidden_fields?: boolean;
       include_editable_data_model?: boolean;
-    }) => {
+    }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.getTable(args.table_id, {
           include_sensitive_fields: args.include_sensitive_fields,
@@ -201,7 +204,8 @@ export function addTableTools(server: any, metabaseClient: MetabaseClient) {
       owner_user_id?: number;
       show_in_getting_started?: boolean;
       entity_type?: string;
-    }) => {
+    }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const { table_id, ...updates } = args;
         const result = await metabaseClient.updateTable(table_id, updates);
@@ -232,7 +236,8 @@ export function addTableTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       table_id: z.number().describe("Table ID"),
     }).strict(),
-    execute: async (args: { table_id: number }) => {
+    execute: async (args: { table_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.getTableFks(args.table_id);
         return JSON.stringify(result, null, 2);
@@ -273,7 +278,8 @@ export function addTableTools(server: any, metabaseClient: MetabaseClient) {
       include_sensitive_fields?: boolean;
       include_hidden_fields?: boolean;
       include_editable_data_model?: boolean;
-    }) => {
+    }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.getTableQueryMetadata(
           args.table_id,
@@ -310,7 +316,8 @@ export function addTableTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       table_id: z.number().describe("Table ID"),
     }).strict(),
-    execute: async (args: { table_id: number }) => {
+    execute: async (args: { table_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.getTableRelated(args.table_id);
         return JSON.stringify(result, null, 2);
@@ -340,7 +347,8 @@ export function addTableTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       card_id: z.number().describe("Card ID for the virtual table"),
     }).strict(),
-    execute: async (args: { card_id: number }) => {
+    execute: async (args: { card_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.getCardTableFks(args.card_id);
         return JSON.stringify(result, null, 2);
@@ -370,7 +378,8 @@ export function addTableTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       card_id: z.number().describe("Card ID for the virtual table"),
     }).strict(),
-    execute: async (args: { card_id: number }) => {
+    execute: async (args: { card_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.getCardTableQueryMetadata(
           args.card_id
@@ -410,7 +419,8 @@ export function addTableTools(server: any, metabaseClient: MetabaseClient) {
       table_id: number;
       filename: string;
       file_content: string;
-    }) => {
+    }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.appendCsvToTable(
           args.table_id,
@@ -444,7 +454,8 @@ export function addTableTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       table_id: z.number().describe("Table ID"),
     }).strict(),
-    execute: async (args: { table_id: number }) => {
+    execute: async (args: { table_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.discardTableFieldValues(
           args.table_id
@@ -481,7 +492,8 @@ export function addTableTools(server: any, metabaseClient: MetabaseClient) {
         .array(z.number())
         .describe("Array of field IDs in desired order"),
     }).strict(),
-    execute: async (args: { table_id: number; field_order: number[] }) => {
+    execute: async (args: { table_id: number; field_order: number[] }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.reorderTableFields(
           args.table_id,
@@ -516,7 +528,8 @@ export function addTableTools(server: any, metabaseClient: MetabaseClient) {
       table_id: z.number().describe("Table ID"),
       csv_file: z.string().describe("CSV file content as string"),
     }).strict(),
-    execute: async (args: { table_id: number; csv_file: string }) => {
+    execute: async (args: { table_id: number; csv_file: string }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.replaceTableCsv(
           args.table_id,
@@ -549,7 +562,8 @@ export function addTableTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       table_id: z.number().describe("Table ID"),
     }).strict(),
-    execute: async (args: { table_id: number }) => {
+    execute: async (args: { table_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.rescanTableFieldValues(
           args.table_id
@@ -581,7 +595,8 @@ export function addTableTools(server: any, metabaseClient: MetabaseClient) {
     parameters: z.object({
       table_id: z.number().describe("Table ID"),
     }).strict(),
-    execute: async (args: { table_id: number }) => {
+    execute: async (args: { table_id: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.syncTableSchema(args.table_id);
         return JSON.stringify(
@@ -618,7 +633,8 @@ export function addTableTools(server: any, metabaseClient: MetabaseClient) {
       table_id: z.number().describe("Table ID"),
       limit: z.number().optional().describe("Row limit (default 1000)"),
     }).strict(),
-    execute: async (args: { table_id: number; limit?: number }) => {
+    execute: async (args: { table_id: number; limit?: number }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.getTableData(
           args.table_id,
@@ -654,7 +670,8 @@ export function addTableTools(server: any, metabaseClient: MetabaseClient) {
       table_id: z.number().describe("Table ID to search in"),
       column_name: z.string().describe("Column name to look up (searches both name and display_name)"),
     }).strict(),
-    execute: async (args: { table_id: number; column_name: string }) => {
+    execute: async (args: { table_id: number; column_name: string }, context: any) => {
+      const metabaseClient = getClient(context);
       try {
         const result = await metabaseClient.getFieldByName(
           args.table_id,

--- a/sse-server.js
+++ b/sse-server.js
@@ -3,7 +3,7 @@ import cors from 'cors';
 import { spawn } from 'child_process';
 
 const app = express();
-const port = 8080;
+const port = process.env.PORT || 8010;
 
 app.use(cors());
 app.use(express.json());
@@ -12,6 +12,14 @@ const connections = new Map();
 
 app.get('/health', (req, res) => {
  res.json({ status: 'ok', service: 'metabase-mcp-server' });
+});
+
+// OAuth discovery endpoint - tells clients no OAuth auth is required
+app.get('/.well-known/oauth-authorization-server', (req, res) => {
+ res.setHeader('Content-Type', 'application/json');
+ res.json({
+   issuer: 'https://data-dev.clay.cl/metabase-mcp'
+ });
 });
 
 app.get('/sse', async (req, res) => {

--- a/sse-server.js
+++ b/sse-server.js
@@ -18,7 +18,7 @@ app.get('/health', (req, res) => {
 app.get('/.well-known/oauth-authorization-server', (req, res) => {
  res.setHeader('Content-Type', 'application/json');
  res.json({
-   issuer: 'https://data-dev.clay.cl/metabase-mcp'
+   issuer: process.env.SSE_SERVER_URL || 'http://localhost:8010'
  });
 });
 

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createAuthenticateHandler, createClientResolver } from '../src/auth.js';
+import { MetabaseClient } from '../src/client/metabase-client.js';
+
+// ── createClientResolver ────────────────────────────────────────────────────
+
+describe('createClientResolver', () => {
+  it('returns the session client when ctx.session.metabaseClient exists', () => {
+    const sessionClient = { id: 'session' } as unknown as MetabaseClient;
+    const getClient = createClientResolver(null);
+    const result = getClient({ session: { metabaseClient: sessionClient } });
+    expect(result).toBe(sessionClient);
+  });
+
+  it('returns the defaultClient when no session client is present', () => {
+    const defaultClient = new MetabaseClient({
+      url: 'http://metabase.test',
+      apiKey: 'key-default',
+    });
+    const getClient = createClientResolver(defaultClient);
+    expect(getClient({})).toBe(defaultClient);
+    expect(getClient(undefined)).toBe(defaultClient);
+  });
+
+  it('prefers the session client over the defaultClient', () => {
+    const sessionClient = { id: 'session' } as unknown as MetabaseClient;
+    const defaultClient = new MetabaseClient({
+      url: 'http://metabase.test',
+      apiKey: 'key-default',
+    });
+    const getClient = createClientResolver(defaultClient);
+    expect(getClient({ session: { metabaseClient: sessionClient } })).toBe(sessionClient);
+  });
+
+  it('throws when both defaultClient is null and no session client', () => {
+    const getClient = createClientResolver(null);
+    expect(() => getClient()).toThrow('No MetabaseClient available');
+    expect(() => getClient({})).toThrow('No MetabaseClient available');
+  });
+});
+
+// ── createAuthenticateHandler ───────────────────────────────────────────────
+
+describe('createAuthenticateHandler', () => {
+  const authenticate = createAuthenticateHandler();
+
+  afterEach(() => {
+    delete process.env.METABASE_URL;
+  });
+
+  it('returns a MetabaseClient when x-metabase-url + x-metabase-api-key are provided', () => {
+    const result = authenticate({
+      headers: {
+        'x-metabase-url': 'http://metabase.test',
+        'x-metabase-api-key': 'test-api-key',
+      },
+    });
+    expect(result.metabaseClient).toBeInstanceOf(MetabaseClient);
+  });
+
+  it('returns a MetabaseClient when x-metabase-url + username/password are provided', () => {
+    const result = authenticate({
+      headers: {
+        'x-metabase-url': 'http://metabase.test',
+        'x-metabase-username': 'admin@test.com',
+        'x-metabase-password': 'secret',
+      },
+    });
+    expect(result.metabaseClient).toBeInstanceOf(MetabaseClient);
+  });
+
+  it('falls back to METABASE_URL env var when x-metabase-url header is absent', () => {
+    process.env.METABASE_URL = 'http://env-metabase.test';
+    const result = authenticate({
+      headers: { 'x-metabase-api-key': 'test-api-key' },
+    });
+    expect(result.metabaseClient).toBeInstanceOf(MetabaseClient);
+  });
+
+  it('throws a 401 Response when URL is missing and METABASE_URL is not set', () => {
+    expect(() =>
+      authenticate({ headers: { 'x-metabase-api-key': 'key' } })
+    ).toThrow(Response);
+
+    try {
+      authenticate({ headers: { 'x-metabase-api-key': 'key' } });
+    } catch (e) {
+      expect((e as Response).status).toBe(401);
+      expect((e as Response).statusText).toMatch(/Missing Metabase URL/);
+    }
+  });
+
+  it('throws a 401 Response when credentials are missing', () => {
+    try {
+      authenticate({ headers: { 'x-metabase-url': 'http://metabase.test' } });
+    } catch (e) {
+      expect((e as Response).status).toBe(401);
+      expect((e as Response).statusText).toMatch(/Missing credentials/);
+    }
+  });
+
+  it('throws a 401 Response when only username is provided (no password)', () => {
+    try {
+      authenticate({
+        headers: {
+          'x-metabase-url': 'http://metabase.test',
+          'x-metabase-username': 'admin@test.com',
+        },
+      });
+    } catch (e) {
+      expect((e as Response).status).toBe(401);
+    }
+  });
+
+  it('each call creates an independent MetabaseClient (session isolation)', () => {
+    const r1 = authenticate({
+      headers: {
+        'x-metabase-url': 'http://metabase-a.test',
+        'x-metabase-api-key': 'key-a',
+      },
+    });
+    const r2 = authenticate({
+      headers: {
+        'x-metabase-url': 'http://metabase-b.test',
+        'x-metabase-api-key': 'key-b',
+      },
+    });
+    expect(r1.metabaseClient).not.toBe(r2.metabaseClient);
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { loadConfig, validateConfig } from '../src/utils/config.js';
+
+describe('loadConfig', () => {
+  const ENV_KEYS = ['METABASE_URL', 'METABASE_API_KEY', 'METABASE_USERNAME', 'METABASE_PASSWORD'];
+  let saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+    ENV_KEYS.forEach((k) => delete process.env[k]);
+  });
+
+  afterEach(() => {
+    ENV_KEYS.forEach((k) => {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    });
+  });
+
+  it('loads config with API key', () => {
+    process.env.METABASE_URL = 'http://metabase.test';
+    process.env.METABASE_API_KEY = 'my-api-key';
+    const config = loadConfig();
+    expect(config.url).toBe('http://metabase.test');
+    expect(config.apiKey).toBe('my-api-key');
+  });
+
+  it('loads config with username/password', () => {
+    process.env.METABASE_URL = 'http://metabase.test';
+    process.env.METABASE_USERNAME = 'user@test.com';
+    process.env.METABASE_PASSWORD = 'secret';
+    const config = loadConfig();
+    expect(config.username).toBe('user@test.com');
+    expect(config.password).toBe('secret');
+  });
+
+  it('throws when METABASE_URL is missing', () => {
+    process.env.METABASE_API_KEY = 'key';
+    expect(() => loadConfig()).toThrow('METABASE_URL');
+  });
+
+  it('throws when neither API key nor username/password are set', () => {
+    process.env.METABASE_URL = 'http://metabase.test';
+    expect(() => loadConfig()).toThrow();
+  });
+});
+
+describe('validateConfig', () => {
+  it('passes for valid config with API key', () => {
+    expect(() =>
+      validateConfig({ url: 'http://metabase.test', apiKey: 'key' })
+    ).not.toThrow();
+  });
+
+  it('passes for valid config with username/password', () => {
+    expect(() =>
+      validateConfig({
+        url: 'http://metabase.test',
+        username: 'user@test.com',
+        password: 'secret',
+      })
+    ).not.toThrow();
+  });
+
+  it('throws for missing URL', () => {
+    expect(() =>
+      validateConfig({ url: '', apiKey: 'key' })
+    ).toThrow('URL is required');
+  });
+
+  it('throws for invalid URL format', () => {
+    expect(() =>
+      validateConfig({ url: 'not-a-url', apiKey: 'key' })
+    ).toThrow('Invalid Metabase URL');
+  });
+
+  it('throws when neither API key nor username/password are provided', () => {
+    expect(() =>
+      validateConfig({ url: 'http://metabase.test' })
+    ).toThrow();
+  });
+});

--- a/tests/metabase-client.test.ts
+++ b/tests/metabase-client.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { MetabaseClient } from '../src/client/metabase-client.js';
+
+describe('MetabaseClient constructor', () => {
+  it('initializes successfully with an API key', () => {
+    expect(
+      () => new MetabaseClient({ url: 'http://metabase.test', apiKey: 'test-key' })
+    ).not.toThrow();
+  });
+
+  it('initializes successfully with username and password', () => {
+    expect(
+      () =>
+        new MetabaseClient({
+          url: 'http://metabase.test',
+          username: 'user@test.com',
+          password: 'secret',
+        })
+    ).not.toThrow();
+  });
+
+  it('throws when neither apiKey nor username/password are provided', () => {
+    expect(
+      () => new MetabaseClient({ url: 'http://metabase.test' })
+    ).toThrow('credentials not provided');
+  });
+
+  it('throws when only username is provided (no password)', () => {
+    expect(
+      () =>
+        new MetabaseClient({
+          url: 'http://metabase.test',
+          username: 'user@test.com',
+        })
+    ).toThrow();
+  });
+
+  it('creates distinct instances for different configs (no shared state)', () => {
+    const clientA = new MetabaseClient({ url: 'http://a.test', apiKey: 'key-a' });
+    const clientB = new MetabaseClient({ url: 'http://b.test', apiKey: 'key-b' });
+    expect(clientA).not.toBe(clientB);
+  });
+});

--- a/tests/tool-filters.test.ts
+++ b/tests/tool-filters.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { parseToolFilterOptions } from '../src/utils/tool-filters.js';
+
+describe('parseToolFilterOptions', () => {
+  let originalArgv: string[];
+
+  beforeEach(() => {
+    originalArgv = process.argv.slice();
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+  });
+
+  it('defaults to essential mode when no flags are passed', () => {
+    process.argv = ['node', 'server.js'];
+    expect(parseToolFilterOptions()).toEqual({ mode: 'essential' });
+  });
+
+  it('returns essential mode for --essential flag', () => {
+    process.argv = ['node', 'server.js', '--essential'];
+    expect(parseToolFilterOptions()).toEqual({ mode: 'essential' });
+  });
+
+  it('returns write mode for --write flag', () => {
+    process.argv = ['node', 'server.js', '--write'];
+    expect(parseToolFilterOptions()).toEqual({ mode: 'write' });
+  });
+
+  it('returns all mode for --all flag', () => {
+    process.argv = ['node', 'server.js', '--all'];
+    expect(parseToolFilterOptions()).toEqual({ mode: 'all' });
+  });
+
+  it('--all takes priority over --write', () => {
+    process.argv = ['node', 'server.js', '--write', '--all'];
+    expect(parseToolFilterOptions()).toEqual({ mode: 'all' });
+  });
+
+  it('--all takes priority over --essential', () => {
+    process.argv = ['node', 'server.js', '--essential', '--all'];
+    expect(parseToolFilterOptions()).toEqual({ mode: 'all' });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Closes #29

## Why this matters

The classic `stdio` transport requires one server process per user with credentials baked in at startup. This makes it incompatible with **modern MCP clients like Claude Code CLI**, which connect to HTTP endpoints and pass credentials per-request. This PR adds HTTP Stream transport support so a single deployed instance can serve many users — each with their own Metabase credentials.

| | stdio (classic) | HTTP Stream (this PR) |
|---|---|---|
| Deployment | One process per user | One shared process |
| Credentials | Env vars at startup | Per-request headers |
| **Claude Code CLI** | ❌ Not supported | ✅ Supported |
| Cursor, Windsurf | ✅ Supported | ✅ Supported |

## Changes

### Core feature
- **`src/auth.ts`** (new): `createAuthenticateHandler()` + `createClientResolver()` — the per-request credential injection logic extracted into a testable module
- **`src/server.ts`**: detects `MCP_TRANSPORT=http`, wires FastMCP `authenticate()` hook to extract `x-metabase-url`, `x-metabase-api-key` (or `x-metabase-username`/`x-metabase-password`) from request headers; falls back to stdio mode with shared client when env var is absent
- **All tool files**: signature changed from a `MetabaseClient` instance to a `getClient(ctx)` resolver so each `execute()` call picks up the session's client
- **`sse-server.js`**: legacy SSE wrapper for clients that only support the older SSE transport

### Tests (31 passing, 0 pre-existing)
- `tests/auth.test.ts` — `createClientResolver` and `createAuthenticateHandler` unit tests
- `tests/metabase-client.test.ts` — constructor with api-key, username/password, invalid-credentials
- `tests/tool-filters.test.ts` — flag parsing and default behaviour
- `tests/config.test.ts` — `loadConfig` / `validateConfig` env var permutations

### Docs
- **README.md**: new "HTTP Stream Transport" section with Claude Code CLI setup instructions, header reference table, and `npm test` command

## Usage — Claude Code CLI

```bash
# Add to current project
claude mcp add --transport http metabase "https://your-server.example.com/mcp" \
  --header "x-metabase-url: https://your-metabase.com" \
  --header "x-metabase-api-key: your_api_key"

# Or globally (available in all projects)
claude mcp add --transport http --scope user metabase "https://your-server.example.com/mcp" \
  --header "x-metabase-url: https://your-metabase.com" \
  --header "x-metabase-api-key: your_api_key"
```

## Test plan

- [ ] `MCP_TRANSPORT=http node dist/server.js` starts HTTP server on port 8011
- [ ] Connect via Claude Code CLI with `x-metabase-url` + `x-metabase-api-key` headers — tools work
- [ ] Connect without headers — server returns 401 with descriptive message
- [ ] Without `MCP_TRANSPORT=http`, server starts in stdio mode (no regression)
- [ ] `npm test` — 31 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)